### PR TITLE
fix: li node isn't center

### DIFF
--- a/src/components/ChartNode.css
+++ b/src/components/ChartNode.css
@@ -10,6 +10,7 @@
 .orgchart ul li {
   display: inline-block;
   position: relative;
+  width: 100%;
 }
 
 /* excluding root node */


### PR DESCRIPTION
if the nodes are not same width, the nodes can't center align