### PR TITLE
Fix a typo in readme.md where propname "zoom" is labeled as "pan"

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@
       <td>If true, the chart can be panned.</td>
     </tr>
     <tr>
-      <td>pan</td>
+      <td>zoom</td>
       <td>boolean</td>
       <td>false</td>
       <td>If true, the chart can be zoomed.</td>


### PR DESCRIPTION
Fix a typo in readme.md where propname "zoom" is labeled as "pan"