### PR TITLE
custom classNames not applied

### DIFF
--- a/src/components/ChartNode.js
+++ b/src/components/ChartNode.js
@@ -40,6 +40,7 @@ const ChartNode = ({
 
   const nodeClass = [
     "oc-node",
+    datasource.className,
     isChildrenCollapsed ? "isChildrenCollapsed" : "",
     allowedDrop ? "allowedDrop" : "",
     selected ? "selected" : ""


### PR DESCRIPTION
nodeClass not picking custom classNames from datasource. datasource.classname is added to the nodeClass array.