### PR TITLE
fix: `collapsed: true` not collapsing children by default

### DIFF
--- a/src/components/ChartNode.js
+++ b/src/components/ChartNode.js
@@ -46,9 +46,9 @@ const ChartNode = ({
   ]
     .filter(item => item)
     .join(" ");
-    
+
   useEffect(() => {
-    if(datasource?.collapsed) {
+    if (datasource?.collapsed) {
       setIsChildrenCollapsed(true);
     }
   }, [datasource])

--- a/src/components/ChartNode.js
+++ b/src/components/ChartNode.js
@@ -46,6 +46,12 @@ const ChartNode = ({
   ]
     .filter(item => item)
     .join(" ");
+    
+  useEffect(() => {
+    if(datasource?.collapsed) {
+      setIsChildrenCollapsed(true);
+    }
+  }, [datasource])
 
   useEffect(() => {
     const subs1 = dragNodeService.getDragInfo().subscribe(draggedInfo => {


### PR DESCRIPTION
In ChartNode component, 
Add useEffect with [datasource] to Check if `collapsed` field is true and collapse children.

closes #43 